### PR TITLE
Feature/build code spliting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ description
 
 |     | before | after |
 | --- | ------ | ----- |
-|     |        |
+|     |        |       |
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@kamo88/react-dialog-hooks",
   "version": "0.0.1",
   "type": "module",
+  "description": "react use dialog hooks & dialog component",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -86,7 +87,13 @@
     "react-component",
     "react-use",
     "focus-trap-react",
-    "focus-trap"
+    "focus-trap",
+    "dialog",
+    "modal",
+    "react-dialog",
+    "react-modal",
+    "hooks",
+    "react-hooks"
   ],
   "author": "kamo88 (https://github.com/kamo88)",
   "license": "Unlicense",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,11 +20,12 @@ export default defineConfig(({ mode }) => ({
       formats: ['es', 'umd'],
     },
     rollupOptions: {
-      external: ['react', 'react-dom'],
+      external: ['react', 'react/jsx-runtime', 'react-dom'],
       output: {
         globals: {
           react: 'React',
-          'react-dom': 'react-dom',
+          'react-dom': 'ReactDOM',
+          'react/jsx-runtime': 'ReactJsxRuntime',
         },
       },
     },


### PR DESCRIPTION
### PR description

- build code spliting
  - external
    - react/jsx-runtime
- add field in package.json
  - description
  - keywords

<details>

<summary>capture</summary>

|     | before | after |
| --- | ------ | ----- |
|     |  <img width="1364" alt="スクリーンショット 2023-08-28 20 07 05" src="https://github.com/kamo88/react-dialog-hooks/assets/62532951/3987ab48-a50e-4d27-88fd-3791b9617435">  | <img width="1366" alt="スクリーンショット 2023-08-28 20 07 19" src="https://github.com/kamo88/react-dialog-hooks/assets/62532951/be2d1d14-1ae1-4dc7-9fde-be5c6d6898a8">|


</details>

### Links

issue: #xxx

### What you need to review

- [ ] changes

### others

others (ex: What we are not doing with this pull request
